### PR TITLE
initial commit of tls streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ support to other operating systems, however these are not there yet.
 
 Span Currently links to the following dependencies in it's build process:
 
+  * [Abseil](https://abseil.io/) - Links to the synchronization part of Abseil
+    for effecient mutexes/scoped mutex locks.
+  * [BoringSSL](https://boringssl.googlesource.com/boringssl/) - Used for
+    TLS/SSL Communications for TLS-Streams.
   * [GLOG](https://github.com/google/glog) - for logging.
   * [GFLAGS](https://github.com/gflags/gflags) - dependency of glog.
   * [LibUnwind](https://www.nongnu.org/libunwind/) - for an efficient setjmp,
     and exceptions.
-  * [Abseil](https://abseil.io/) - Links to the synchronization part of Abseil
-    for effecient mutexes/scoped mutex locks.
 
 It should also be noted we bundle: [Slimsig](https://github.com/ilsken/slimsig)
 as part of our codebase (e.g. doesn't require linking too). The license for

--- a/span/BUILD
+++ b/span/BUILD
@@ -12,6 +12,7 @@ cc_library(
   ]),
   deps = [
     "@com_google_absl//absl/synchronization",
+    "@boringssl//:ssl",
     "//tools/cpp/glog:glog-cxx",
     "//tools/cpp/gflags:gflags-cxx",
     "//tools/cpp/libunwind:libunwind-cxx",
@@ -30,8 +31,7 @@ GenCcTestRules(
   ]),
   deps = [
     ":span",
-    "@com_google_googletest//:gtest_main",
-    "@com_google_absl//absl/synchronization"
+    "@com_google_googletest//:gtest_main"
   ],
 )
 

--- a/span/src/span/exceptions/Assert.hh
+++ b/span/src/span/exceptions/Assert.hh
@@ -13,6 +13,10 @@ namespace span {
     ::std::terminate();                       \
   }
 
+#define SPAN_NOT_REACHED(x)                      \
+  LOG(FATAL) << "Reached unreachable area: " #x; \
+  ::std::terminate();
+
 #define SPAN_VERIFY(x) SPAN_ASSERT(x)
 
   }  // namespace exceptions

--- a/span/src/span/io/streams/Filter.cpp
+++ b/span/src/span/io/streams/Filter.cpp
@@ -1,0 +1,41 @@
+#include "span/io/streams/Filter.hh"
+
+#if __has_include(<string_view>)
+#include <string_view>
+using std::string_view;
+#else
+#include <experimental/string_view>
+using std::experimental::string_view;
+#endif
+
+#include "span/Common.hh"
+#include "span/exceptions/Assert.hh"
+
+namespace span {
+  namespace io {
+    namespace streams {
+      int64 MutatingFilterStream::seek(int64 offset, Anchor anchor) {
+        SPAN_NOT_REACHED("MutatingFilterStream::seek");
+      }
+
+      int64 MutatingFilterStream::size() {
+        SPAN_NOT_REACHED("MutatingFilterStream::size");
+      }
+
+      void MutatingFilterStream::truncate(int64 size) {
+        SPAN_NOT_REACHED("MutatingFilterStream::truncate");
+      }
+
+      ptrdiff_t MutatingFilterStream::find(char delim, size_t sanitySize, bool throwIfNotFound) {
+        SPAN_NOT_REACHED("MutatingFilterStream::find");
+      }
+      ptrdiff_t MutatingFilterStream::find(const string_view str, size_t sanitySize, bool throwIfNotFound) {
+        SPAN_NOT_REACHED("MutatingFilterStream::find");
+      }
+
+      void MutatingFilterStream::unread(const Buffer *buff, size_t len) {
+        SPAN_NOT_REACHED("MutatingFilterStream::unread");
+      }
+    }  // namespace streams
+  }  // namespace io
+}  // namespace span

--- a/span/src/span/io/streams/Filter.hh
+++ b/span/src/span/io/streams/Filter.hh
@@ -1,0 +1,126 @@
+#ifndef SPAN_SRC_SPAN_IO_STREAMS_FILTER_HH_
+#define SPAN_SRC_SPAN_IO_STREAMS_FILTER_HH_
+
+#include <memory>
+
+#if __has_include(<string_view>)
+#include <string_view>
+using std::string_view;
+#else
+#include <experimental/string_view>
+using std::experimental::string_view;
+#endif
+
+#include "span/Common.hh"
+#include "span/io/streams/Buffer.hh"
+#include "span/io/streams/Stream.hh"
+#include "span/third_party/slimsig/slimsig.hh"
+
+namespace span {
+  namespace io {
+    namespace streams {
+      /**
+       * When inheriting from FilterStream, use parent()->xxx to call
+       * method xxx on the parent stream.
+       *
+       * FilterStreams *must* implement one of the possible overloads for read()
+       * and write(), even if it's just calling the parent version. Otherwise the
+       * adapter functions in the base Stream will just call each other, and blow
+       * the stack.
+       */
+      class FilterStream : public Stream {
+      public:
+        typedef std::shared_ptr<FilterStream> ptr;
+
+        explicit FilterStream(Stream::ptr parent, bool own = true) : parent_(parent), own_(own) {}
+
+        Stream::ptr parent() { return parent_; }
+        void parent(Stream::ptr parent) { parent_ = parent; }
+        bool ownsParent() { return own_; }
+        void ownsParent(bool own) { own_ = own; }
+
+        bool supportsHalfClose() { return parent_->supportsHalfClose(); }
+        bool supportsRead() { return parent_->supportsRead(); }
+        bool supportsWrite() { return parent_->supportsWrite(); }
+        bool supportsSeek() { return parent_->supportsSeek(); }
+        bool supportsTell() { return parent_->supportsTell(); }
+        bool supportsSize() { return parent_->supportsSize(); }
+        bool supportsTruncate() { return parent_->supportsTruncate(); }
+        bool supportsFind() { return parent_->supportsFind(); }
+        bool supportsUnread() { return parent_->supportsUnread(); }
+
+        void close(CloseType type = BOTH) {
+          if (own_) {
+            parent_->close(type);
+          }
+        }
+        void cancelRead() { parent_->cancelRead(); }
+        void cancelWrite() { parent_->cancelWrite(); }
+
+        int64 seek(int64 offset, Anchor anchor = BEGIN) {
+          return parent_->seek(offset, anchor);
+        }
+        int64 size() {
+          return parent_->size();
+        }
+
+        void truncate(int64 size) {
+          parent_->truncate(size);
+        }
+        void flush(bool flushParent = true) {
+          if (flushParent) {
+            parent_->flush(true);
+          }
+        }
+
+        ptrdiff_t find(char delim, size_t sanitySize = ~0, bool throwIfNotFound = true) {
+          return parent_->find(delim, sanitySize, throwIfNotFound);
+        }
+        ptrdiff_t find(const string_view str, size_t sanitySize = ~0, bool throwIfNotFound = true) {
+          return parent_->find(str, sanitySize, throwIfNotFound);
+        }
+
+        void unread(const Buffer *buff, size_t len) {
+          return parent_->unread(buff, len);
+        }
+
+        slimsig::signal_t<void()>::connection onRemoteClose(const std::function<void()> dg) {
+          return parent_->onRemoteClose(dg);
+        }
+
+      private:
+        Stream::ptr parent_;
+        bool own_;
+      };
+
+      /**
+       * A mutating filter stream is one that declares that it changes the data
+       * as it flows through it. It implicitly turns off and asserts features
+       * that would need to be implemented by the inheritor, instead of
+       * defaulting to the parent streams implementation.
+       */
+      class MutatingFilterStream : public FilterStream {
+      public:
+        bool supportsSeek() { return false; }
+        bool supportsTell() { return supportsSeek(); }
+        bool supportsSize() { return false; }
+        bool supportsTruncate() { return false; }
+        bool supportsFind() { return false; }
+        bool supportsUnread() { return false; }
+
+        int64 seek(int64 offset, Anchor anchor = BEGIN);
+        int64 size();
+        void truncate(int64 size);
+
+        ptrdiff_t find(char delim, size_t sanitySize = ~0, bool throwIfNotFound = true);
+        ptrdiff_t find(const string_view str, size_t sanitySize = ~0, bool throwIfNotFound = true);
+        void unread(const Buffer *buff, size_t len);
+
+      protected:
+        explicit MutatingFilterStream(Stream::ptr parent, bool owns = true) : FilterStream(parent, owns) {}
+      };
+    }  // namespace streams
+  }  // namespace io
+}  // namespace span
+
+#endif  // SPAN_SRC_SPAN_IO_STREAMS_FILTER_HH_

--- a/span/src/span/io/streams/Pipe.cpp
+++ b/span/src/span/io/streams/Pipe.cpp
@@ -1,0 +1,359 @@
+#include "span/io/streams/Pipe.hh"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "span/Common.hh"
+#include "span/exceptions/Assert.hh"
+#include "span/fibers/Fiber.hh"
+#include "span/fibers/Scheduler.hh"
+#include "span/io/streams/Buffer.hh"
+#include "span/io/streams/File.hh"
+#include "span/io/streams/Stream.hh"
+#include "span/third_party/slimsig/slimsig.hh"
+
+#if PLATFORM == PLATFORM_DARWIN || UNIX_FLAVOUR == UNIX_FLAVOUR_OSX
+#include <crt_externs.h>
+#endif
+
+#include "absl/synchronization/mutex.h"
+
+namespace span {
+  namespace io {
+    namespace streams {
+      class PipeStream : public Stream {
+        friend std::pair<Stream::ptr, Stream::ptr> pipeStream(size_t);
+
+      public:
+        typedef std::shared_ptr<PipeStream> ptr;
+        typedef std::weak_ptr<PipeStream> weak_ptr;
+
+        explicit PipeStream(size_t buffSize);
+        ~PipeStream();
+
+        bool supportsHalfClose() { return true; }
+        bool supportsRead() { return true; }
+        bool supportsWrite() { return true; }
+
+        void close(CloseType type = BOTH);
+        using Stream::read;
+        size_t read(Buffer *buff, size_t len);
+        void cancelRead();
+        using Stream::write;
+        size_t write(const Buffer *buff, size_t len);
+        void cancelWrite();
+        void flush(bool flushParent = true);
+
+        slimsig::signal_t<void()>::connection onRemoteClose(const std::function<void()> dg);
+
+      private:
+        PipeStream::weak_ptr otherStream_;
+        std::shared_ptr<absl::Mutex> mutex_;
+        Buffer readBuff_;
+        size_t buffSize_;
+        bool cancelledRead_, cancelledWrite_;
+        CloseType closed_, otherClosed_;
+        span::fibers::Scheduler *pendingWriterScheduler, *pendingReaderScheduler;
+        std::shared_ptr<span::fibers::Fiber> pendingWriter_, pendingReader_;
+        slimsig::signal_t<void()> onRemoteClose_;
+      };
+
+      PipeStream::PipeStream(size_t buffSize) : buffSize_(buffSize),
+        cancelledRead_(false), cancelledWrite_(false), closed_(NONE),
+        otherClosed_(NONE), pendingWriterScheduler(NULL),
+        pendingReaderScheduler(NULL) {}
+
+      PipeStream::~PipeStream() {
+        DLOG(INFO) << this << " destructing";
+        PipeStream::ptr otherStream = otherStream_.lock();
+        absl::MutexLock _lock(mutex_.get());
+        if (otherStream) {
+          SPAN_ASSERT(!otherStream->pendingReader_);
+          SPAN_ASSERT(!otherStream->pendingReaderScheduler);
+          SPAN_ASSERT(!otherStream->pendingWriter_);
+          SPAN_ASSERT(!otherStream->pendingWriterScheduler);
+
+          if (!readBuff_.readAvailable()) {
+            otherStream->otherClosed_ = static_cast<CloseType>(otherStream->otherClosed_ | READ);
+          } else {
+            otherStream->otherClosed_ = static_cast<CloseType>(otherStream->otherClosed_ & ~READ);
+          }
+          otherStream->onRemoteClose_.emit();
+        }
+        if (pendingReader_) {
+          SPAN_ASSERT(pendingReaderScheduler);
+          DLOG(INFO) << otherStream << " scheduling read";
+          pendingReaderScheduler->schedule(pendingReader_);
+          pendingReader_.reset();
+          pendingReaderScheduler = NULL;
+        }
+        if (pendingWriter_) {
+          SPAN_ASSERT(pendingWriterScheduler);
+          DLOG(INFO) << otherStream << " scheduling write";
+          pendingWriterScheduler->schedule(pendingWriter_);
+          pendingWriter_.reset();
+          pendingWriterScheduler = NULL;
+        }
+      }
+
+      void PipeStream::close(CloseType type) {
+        PipeStream::ptr otherStream = otherStream_.lock();
+        absl::MutexLock _lock(mutex_.get());
+        bool closeWriteFirstTime = !(closed_ & WRITE) && (type & WRITE);
+        closed_ = static_cast<CloseType>(closed_ | type);
+        if (otherStream) {
+          otherStream->otherClosed_ = closed_;
+          if (closeWriteFirstTime) {
+            otherStream->onRemoteClose_.emit();
+          }
+        }
+        if (pendingReader_ && (closed_ & WRITE)) {
+          SPAN_ASSERT(pendingReaderScheduler);
+          DLOG(INFO) << otherStream << " scheduling read";
+          pendingReaderScheduler->schedule(pendingReader_);
+          pendingReader_.reset();
+          pendingReaderScheduler = NULL;
+        }
+        if (pendingWriter_ && (closed_ & READ)) {
+          SPAN_ASSERT(pendingWriterScheduler);
+          DLOG(INFO) << otherStream << " shceduling write";
+          pendingWriterScheduler->schedule(pendingWriter_);
+          pendingWriter_.reset();
+          pendingWriterScheduler = NULL;
+        }
+      }
+
+      size_t PipeStream::read(Buffer *buff, size_t len) {
+        SPAN_ASSERT(len != 0);
+
+        while (true) {
+          {
+            PipeStream::ptr otherStream = otherStream_.lock();
+            absl::MutexLock _lock(mutex_.get());
+            if (closed_ & READ) {
+              throw std::runtime_error("Broken Pipe!");
+            }
+            if (!otherStream && !(otherClosed_ & WRITE)) {
+              throw std::runtime_error("Broken Pipe!");
+            }
+            size_t avail = readBuff_.readAvailable();
+            if (avail > 0) {
+              size_t todo = std::min<size_t>(len, avail);
+              buff->copyIn(&readBuff_, todo);
+              readBuff_.consume(todo);
+              if (pendingWriter_) {
+                SPAN_ASSERT(pendingWriterScheduler);
+                DLOG(INFO) << otherStream << " scheduling write";
+                pendingWriterScheduler->schedule(pendingWriter_);
+                pendingWriter_.reset();
+                pendingWriterScheduler = NULL;
+              }
+              DLOG(INFO) << this << " read(" << len << "): " << todo;
+              return todo;
+            }
+
+            if (otherClosed_ & WRITE) {
+              DLOG(INFO) << this << " read(" << len << "): " << 0;
+              return 0;
+            }
+
+            if (cancelledRead_) {
+              throw std::runtime_error("Aborted");
+            }
+
+            // Wait for the other stream to schedule us;
+            SPAN_ASSERT(!otherStream->pendingReader_);
+            SPAN_ASSERT(!otherStream->pendingReaderScheduler);
+            DLOG(INFO) << this << " waiting to read";
+            otherStream->pendingReader_ = span::fibers::Fiber::getThis();
+            otherStream->pendingReaderScheduler = span::fibers::Scheduler::getThis();
+          }
+
+          try {
+            span::fibers::Scheduler::yieldTo();
+          } catch (...) {
+            PipeStream::ptr otherStream = otherStream_.lock();
+            absl::MutexLock _lock(mutex_.get());
+            if (otherStream && otherStream->pendingReader_ == span::fibers::Fiber::getThis()) {
+              SPAN_ASSERT(otherStream->pendingReaderScheduler == span::fibers::Scheduler::getThis());
+              otherStream->pendingReader_.reset();
+              otherStream->pendingReaderScheduler = NULL;
+            }
+            throw;
+          }
+        }
+      }
+
+      void PipeStream::cancelRead() {
+        PipeStream::ptr otherStream = otherStream_.lock();
+        absl::MutexLock _lock(mutex_.get());
+        cancelledRead_ = true;
+        if (otherStream && otherStream->pendingReader_) {
+          SPAN_ASSERT(otherStream->pendingReaderScheduler);
+          DLOG(INFO) << this << " cancelling read";
+          otherStream->pendingReaderScheduler->schedule(otherStream->pendingReader_);
+          otherStream->pendingReader_.reset();
+          otherStream->pendingReaderScheduler = NULL;
+        }
+      }
+
+      size_t PipeStream::write(const Buffer *buff, size_t len) {
+        SPAN_ASSERT(len != 0);
+
+        while (true) {
+          {
+            PipeStream::ptr otherStream = otherStream_.lock();
+            absl::MutexLock _lock(mutex_.get());
+            if (closed_ & WRITE) {
+              throw std::runtime_error("Broken Pipe");
+            }
+            if (!otherStream || (otherStream->closed_ & READ)) {
+              throw std::runtime_error("Broken Pipe");
+            }
+
+            size_t available = otherStream->readBuff_.readAvailable();
+            size_t todo = std::min<size_t>(buffSize_ - available, len);
+            if (todo != 0) {
+              otherStream->readBuff_.copyIn(buff, todo);
+              if (pendingReader_) {
+                SPAN_ASSERT(pendingReaderScheduler);
+                DLOG(INFO) << otherStream << " scheduling read";
+                pendingReaderScheduler->schedule(pendingReader_);
+                pendingReader_.reset();
+                pendingReaderScheduler = NULL;
+              }
+              DLOG(INFO) << this << " write(" << len << "): " << todo;
+              return todo;
+            }
+
+            if (cancelledWrite_) {
+              throw std::runtime_error("Operation aborted");
+            }
+
+            // Wait for other stream to schedule us.
+            SPAN_ASSERT(!otherStream->pendingWriter_);
+            SPAN_ASSERT(!otherStream->pendingWriterScheduler);
+            DLOG(INFO) << this << " waiting to write";
+            otherStream->pendingWriter_ = span::fibers::Fiber::getThis();
+            otherStream->pendingWriterScheduler = span::fibers::Scheduler::getThis();
+          }
+
+          try {
+            span::fibers::Scheduler::yieldTo();
+          } catch (...) {
+            PipeStream::ptr otherStream = otherStream_.lock();
+            absl::MutexLock _lock(mutex_.get());
+            if (otherStream && otherStream->pendingWriter_ == span::fibers::Fiber::getThis()) {
+              SPAN_ASSERT(otherStream->pendingWriterScheduler = span::fibers::Scheduler::getThis());
+              otherStream->pendingWriter_.reset();
+              otherStream->pendingWriterScheduler = NULL;
+            }
+            throw;
+          }
+        }
+      }
+
+      void PipeStream::cancelWrite() {
+        PipeStream::ptr otherStream = otherStream_.lock();
+        absl::MutexLock _lock(mutex_.get());
+        cancelledWrite_ = true;
+        if (otherStream && otherStream->pendingWriter_) {
+          SPAN_ASSERT(otherStream->pendingWriterScheduler);
+          DLOG(INFO) << this << " cancelling write";
+          otherStream->pendingWriterScheduler->schedule(otherStream->pendingWriter_);
+          otherStream->pendingWriter_.reset();
+          otherStream->pendingWriterScheduler = NULL;
+        }
+      }
+
+      void PipeStream::flush(bool flushParent) {
+        while (true) {
+          {
+            PipeStream::ptr otherStream = otherStream_.lock();
+            absl::MutexLock _lock(mutex_.get());
+            if (cancelledWrite_) {
+              throw std::runtime_error("Operation Aborted");
+            }
+            if (!otherStream) {
+              // See if they read everything before destructing.
+              if (otherClosed_ & READ) {
+                return;
+              }
+              throw std::runtime_error("Broken Pipe");
+            }
+
+            if (otherStream->readBuff_.readAvailable() == 0) {
+              return;
+            }
+            if (otherStream->closed_ & READ) {
+              throw std::runtime_error("Broken Pipe");
+            }
+
+            // Wait for other stream to schedule us.
+            SPAN_ASSERT(!otherStream->pendingWriter_);
+            SPAN_ASSERT(!otherStream->pendingWriterScheduler);
+            DLOG(INFO) << this << " waiting to flush";
+            otherStream->pendingWriter_ = span::fibers::Fiber::getThis();
+            otherStream->pendingWriterScheduler = span::fibers::Scheduler::getThis();
+          }
+
+          try {
+            span::fibers::Scheduler::yieldTo();
+          } catch (...) {
+            PipeStream::ptr otherStream = otherStream_.lock();
+            absl::MutexLock _lock(mutex_.get());
+            if (otherStream && otherStream->pendingWriter_ == span::fibers::Fiber::getThis()) {
+              SPAN_ASSERT(otherStream->pendingWriterScheduler == span::fibers::Scheduler::getThis());
+              otherStream->pendingWriter_.reset();
+              otherStream->pendingWriterScheduler = NULL;
+            }
+            throw;
+          }
+        }
+      }
+
+      slimsig::signal_t<void()>::connection PipeStream::onRemoteClose(const std::function<void()> dg) {
+        return onRemoteClose_.connect(dg);
+      }
+
+      std::pair<Stream::ptr, Stream::ptr> pipeStream(size_t buffSize) {
+        if (buffSize == ~0u) {
+          buffSize = 65536;
+        }
+        std::pair<PipeStream::ptr, PipeStream::ptr> result;
+        result.first.reset(new PipeStream(buffSize));
+        result.second.reset(new PipeStream(buffSize));
+        DLOG(INFO) << "pipeStream(" << buffSize << "): {" << result.first << ", " << result.second << "}";
+        result.first->otherStream_ = result.second;
+        result.second->otherStream_ = result.first;
+        result.first->mutex_.reset(new absl::Mutex());
+        result.second->mutex_ = result.first->mutex_;
+        return result;
+      }
+
+      std::pair<NativeStream::ptr, NativeStream::ptr> anonymousPipe(span::io::IOManager *ioManager) {
+        std::pair<NativeStream::ptr, NativeStream::ptr> result;
+#if PLATFORM != PLATFORM_WIN32
+        int fds[2];
+        if (pipe(fds)) {
+          throw std::runtime_error("pipe");
+        }
+        try {
+          result.first.reset(new FDStream(fds[0], ioManager));
+          result.second.reset(new FDStream(fds[1], ioManager));
+        } catch (...) {
+          if (!result.first) {
+            close(fds[0]);
+          }
+          if (!result.second) {
+            close(fds[1]);
+          }
+          throw;
+        }
+#endif
+        return result;
+      }
+    }  // namespace streams
+  }  // namespace io
+}  // namespace span

--- a/span/src/span/io/streams/Pipe.hh
+++ b/span/src/span/io/streams/Pipe.hh
@@ -1,0 +1,33 @@
+#ifndef SPAN_SRC_SPAN_IO_STREAMS_PIPE_HH_
+#define SPAN_SRC_SPAN_IO_STREAMS_PIPE_HH_
+
+#include <utility>
+
+#include "span/Common.hh"
+#include "span/io/streams/Stream.hh"
+#if PLATFORM != PLATFORM_WIN32
+#include "span/io/streams/Fd.hh"
+#endif
+
+namespace span {
+  namespace io {
+    class IOManager;
+
+    namespace streams {
+      /**
+       *  Create a user-space only, full-duplex anonymous pipe.
+       */
+      std::pair<Stream::ptr, Stream::ptr> pipeStream(size_t buffSize = ~0);
+
+      /**
+       * Create a kernel-level, half-duplex anonymous pipe.
+       *
+       * The streams created by this function will have a file handle, and are
+       * suitable for usage with native OS APIs.
+       */
+      std::pair<NativeStream::ptr, NativeStream::ptr> anonymousPipe(IOManager *ioManager = NULL);
+    }  // namespace streams
+  }  // namespace io
+}  // namespace span
+
+#endif  // SPAN_SRC_SPAN_IO_STREAMS_PIPE_HH_

--- a/span/src/span/io/streams/Tls.cpp
+++ b/span/src/span/io/streams/Tls.cpp
@@ -1,0 +1,583 @@
+#include "span/io/streams/Tls.hh"
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "span/Common.hh"
+#include "span/exceptions/Assert.hh"
+
+#include "glog/logging.h"
+#include "openssl/err.h"
+#include "openssl/evp.h"
+#include "openssl/x509v3.h"
+
+namespace span {
+  namespace io {
+    namespace streams {
+      namespace {
+        static struct TLSInitializer {
+          TLSInitializer() {
+            SSL_library_init();
+            SSL_load_error_strings();
+          }
+          ~TLSInitializer() {
+            ERR_free_strings();
+            CRYPTO_cleanup_all_ex_data();
+            EVP_cleanup();
+          }
+        } gInit;
+      }  // namespace
+
+      static bool hasBoringSSLError() {
+        uint32 err = ERR_peek_error();
+        return (err != SSL_ERROR_NONE);
+      }
+
+      static std::string getBoringSSLErrorMessage() {
+        std::ostringstream os;
+        uint32 err;
+        char buff[120];
+        while ((err = ERR_get_error()) != SSL_ERROR_NONE) {
+          if (!os.str().empty()) {
+            os << "\n";
+          }
+          os << ERR_error_string(err, buff);
+        }
+        return os.str();
+      }
+
+      BoringSSLException::BoringSSLException() : std::runtime_error(getBoringSSLErrorMessage()) {}
+
+      std::string CertificateVerificationException::constructMessage(int32 verifyResult) {
+        return X509_verify_cert_error_string(verifyResult);
+      }
+
+      std::shared_ptr<SSL_CTX> TLSStream::generateSelfSignedCertificate(const std::string commonName) {
+        std::shared_ptr<SSL_CTX> ctx;
+        ctx.reset(SSL_CTX_new(TLS_method()), &SSL_CTX_free);
+        std::shared_ptr<X509> cert;
+        std::shared_ptr<EVP_PKEY> pkey;
+
+        pkey.reset(EVP_PKEY_new(), &EVP_PKEY_free);
+        if (!pkey) {
+          throw std::runtime_error("bad alloc");
+        }
+
+        // Use secp384r1, since chrome does not support secp521r1.
+        int eccgrp = OBJ_txt2nid("secp384r1");
+        if (eccgrp == NID_undef) {
+          throw std::runtime_error("curve secp384r1 not supported");
+        }
+        EC_KEY *ec_key = EC_KEY_new_by_curve_name(eccgrp);
+        if (!ec_key) {
+          throw std::runtime_error("EC_KEY_new_by_curve_name error");
+        }
+        EC_KEY_set_asn1_flag(ec_key, OPENSSL_EC_NAMED_CURVE);
+        if (!EC_KEY_generate_key(ec_key)) {
+          throw std::runtime_error("EC_KEY_generate_key error");
+        }
+        SPAN_ASSERT(EVP_PKEY_assign_EC_KEY(pkey.get(), ec_key) == 1);
+
+        cert.reset(X509_new(), &X509_free);
+        if (!cert) {
+          throw std::runtime_error("bad alloc");
+        }
+
+        X509_set_version(cert.get(), 2);
+        // Use 1 instead of 0, since some HTTP Servers/Clients are dumb.
+        ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), 1);
+        // We're valid for a year.
+        X509_gmtime_adj(X509_get_notBefore(cert.get()), 0);
+        X509_gmtime_adj(X509_get_notAfter(cert.get()), 31536000L);
+        X509_set_pubkey(cert.get(), pkey.get());
+        // Now we set our full name.
+        X509_NAME * name = X509_get_subject_name(cert.get());
+        X509_NAME_add_entry_by_txt(
+          name,
+          "C",
+          MBSTRING_ASC,
+          reinterpret_cast<const unsigned char *>("US"),
+          -1,
+          -1,
+          0);
+        X509_NAME_add_entry_by_txt(
+          name,
+          "O",
+          MBSTRING_ASC,
+          reinterpret_cast<const unsigned char*>("SelfSigned, Inc."),
+          -1,
+          -1,
+          0);
+        X509_NAME_add_entry_by_txt(
+          name,
+          "CN",
+          MBSTRING_ASC,
+          // Ensure it's null terminated.
+          reinterpret_cast<const unsigned char *>(commonName.c_str()),
+          -1,
+          -1,
+          0);
+        X509_set_issuer_name(cert.get(), name);
+        // Sign the certificate.
+        X509_sign(cert.get(), pkey.get(), EVP_sha512());
+
+        // Have the ctx use the certificate/key.
+        SSL_CTX_use_certificate(ctx.get(), cert.get());
+        SSL_CTX_use_PrivateKey(ctx.get(), pkey.get());
+
+        return ctx;
+      }
+
+      TLSStream::TLSStream(Stream::ptr parent, bool client, bool own, SSL_CTX *ctx) :
+        MutatingFilterStream(parent, own) {
+        SPAN_ASSERT(parent);
+        clearTLSError();
+        if (ctx) {
+          ctx_.reset(ctx, &nop<SSL_CTX *>);
+        } else if (!client) {
+          // Generate our own cert.
+          ctx_ = generateSelfSignedCertificate();
+        } else {
+          ctx_.reset(SSL_CTX_new(TLS_method()), &SSL_CTX_free);
+        }
+
+        if (!ctx_) {
+          SPAN_ASSERT(hasBoringSSLError());
+          throw BoringSSLException(getBoringSSLErrorMessage());
+        }
+
+        ssl_.reset(SSL_new(ctx_.get()), &SSL_free);
+
+        if (!ssl_) {
+          SPAN_ASSERT(hasBoringSSLError());
+          throw BoringSSLException(getBoringSSLErrorMessage());
+        }
+
+        readBio = BIO_new(BIO_s_mem());
+        writeBio = BIO_new(BIO_s_mem());
+        if (!readBio || !writeBio) {
+          if (readBio) {
+            BIO_free(readBio);
+          }
+          if (writeBio) {
+            BIO_free(writeBio);
+          }
+          SPAN_ASSERT(hasBoringSSLError());
+          throw BoringSSLException(getBoringSSLErrorMessage());
+        }
+
+        BIO_set_mem_eof_return(readBio, -1);
+
+        SSL_set_bio(ssl_.get(), readBio, writeBio);
+      }
+
+      void TLSStream::clearTLSError() {
+        ERR_clear_error();
+      }
+
+      void TLSStream::close(CloseType type) {
+        SPAN_ASSERT(type == BOTH);
+        if (!(sslCallWithLock(std::bind(SSL_get_shutdown, ssl_.get()), NULL) & SSL_SENT_SHUTDOWN)) {
+          uint32 error = SSL_ERROR_NONE;
+          const int32 result = sslCallWithLock(std::bind(SSL_shutdown, ssl_.get()), &error);
+          if (result <= 0) {
+            DLOG(INFO) << this << " SSL_shutdown(" << ssl_.get() << "): " << result << " (" << error << ")";
+            if (error != SSL_ERROR_NONE && error != SSL_ERROR_ZERO_RETURN) {
+              throw BoringSSLException(getBoringSSLErrorMessage());
+            }
+          }
+
+          flush(false);
+        }
+
+        while (!(sslCallWithLock(std::bind(SSL_get_shutdown, ssl_.get()), NULL) & SSL_RECEIVED_SHUTDOWN)) {
+          uint32 error = SSL_ERROR_NONE;
+          const int32 result = sslCallWithLock(std::bind(SSL_shutdown, ssl_.get()), &error);
+          DLOG(INFO) << this << " SSL_shutdown(" << ssl_.get() << "): " << result << " (" << error << ")";
+          if (result > 0) {
+            break;
+          }
+
+          switch (error) {
+            case SSL_ERROR_NONE:
+            case SSL_ERROR_ZERO_RETURN:
+              break;
+            case SSL_ERROR_WANT_READ:
+              flush();
+              wantRead();
+              continue;
+            case SSL_ERROR_WANT_WRITE:
+            case SSL_ERROR_WANT_CONNECT:
+            case SSL_ERROR_WANT_ACCEPT:
+            case SSL_ERROR_WANT_X509_LOOKUP:
+              SPAN_NOT_REACHED("SSLError");
+            case SSL_ERROR_SYSCALL:
+              if (hasBoringSSLError()) {
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_shutdown(" << ssl_.get() << "): "
+                  << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+              LOG(WARNING) << this << " SSL_shutdown(" << ssl_.get() << "): "
+                << result << " (" << error << ")";
+              if (result == 0) {
+                break;
+              }
+            case SSL_ERROR_SSL:
+              {
+                SPAN_ASSERT(hasBoringSSLError());
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_shutdown(" << ssl_.get() << "): "
+                  << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+            default:
+              SPAN_NOT_REACHED("default openssl while");
+          }
+          break;
+        }
+
+        parent()->close();
+      }
+
+      size_t TLSStream::read(void *buff, size_t len) {
+        const size_t toRead = std::min<size_t>(0x0fffffff, len);
+        while (true) {
+          uint32 error = SSL_ERROR_NONE;
+          const int32 result = sslCallWithLock(std::bind(SSL_read, ssl_.get(), buff, toRead), &error);
+          if (result > 0) {
+            return result;
+          }
+
+          DLOG(INFO) << this << " SSL_read(" << ssl_.get() << ", " << toRead
+            << "): " << result << " (" << error << ")";
+          switch (error) {
+            case SSL_ERROR_NONE:
+              return result;
+            case SSL_ERROR_ZERO_RETURN:
+              // Received close_notify message.
+              SPAN_ASSERT(result == 0);
+              return 0;
+            case SSL_ERROR_WANT_READ:
+              wantRead();
+              continue;
+            case SSL_ERROR_WANT_WRITE:
+            case SSL_ERROR_WANT_CONNECT:
+            case SSL_ERROR_WANT_ACCEPT:
+            case SSL_ERROR_WANT_X509_LOOKUP:
+              SPAN_NOT_REACHED("ssl error multi-case switch.");
+            case SSL_ERROR_SYSCALL:
+              if (hasBoringSSLError()) {
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_read(" << ssl_.get() << ", "
+                  << toRead << "): " << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+              LOG(WARNING) << this << " SSL_read(" << ssl_.get() << ", "
+                << toRead << "): " << result << " (" << error << ")";
+              if (result == 0) {
+                return 0;
+              }
+              throw std::runtime_error("SSL_read");
+            case SSL_ERROR_SSL:
+              {
+                SPAN_ASSERT(hasBoringSSLError());
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_read(" << ssl_.get() << ", "
+                  << toRead << "): " << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+            default:
+              SPAN_NOT_REACHED("default openssl switch");
+          }
+        }
+      }
+
+      size_t TLSStream::write(const Buffer *buff, size_t len) {
+        // SSL_write will create at least two SSL records for each call -
+        // one for data, and one tiny one for the checksum or IV or something.
+        // Dealing with lots of extra records can take some serious CPU time
+        // server-side, so we want to provide it with as much data as possible,
+        // even if that means reallocating.  That's why we use pass the flag to
+        // coalesce small segments, instead of only doing the first available
+        // segment.
+        return Stream::write(buff, len, true);
+      }
+
+      size_t TLSStream::write(const void *buff, size_t len) {
+        flush(false);
+
+        if (len == 0) {
+          return 0;
+        }
+
+        const size_t toWrite = std::min<size_t>(0x7fffffff, len);
+        while (true) {
+          uint32 error = SSL_ERROR_NONE;
+          const int32 result = sslCallWithLock(std::bind(SSL_write, ssl_.get(), buff, toWrite), &error);
+          if (result > 0) {
+            return result;
+          }
+
+          DLOG(INFO) << this << " SSL_write(" << ssl_.get() << ", " << toWrite
+            << "): " << result << " (" << error << ")";
+          switch (error) {
+            case SSL_ERROR_NONE:
+              return result;
+            case SSL_ERROR_ZERO_RETURN:
+              // Received close_notify message.
+              SPAN_ASSERT(result != 0);
+              return result;
+            case SSL_ERROR_WANT_READ:
+              BoringSSLException("SSL_write generated SSL_ERROR_WANT_READ");
+            case SSL_ERROR_WANT_WRITE:
+            case SSL_ERROR_WANT_CONNECT:
+            case SSL_ERROR_WANT_ACCEPT:
+            case SSL_ERROR_WANT_X509_LOOKUP:
+              SPAN_NOT_REACHED("SSL_WRITE multi-case switch");
+            case SSL_ERROR_SYSCALL:
+              if (hasBoringSSLError()) {
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_write(" << ssl_.get() << ", "
+                  << toWrite << "): " << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+              LOG(ERROR) << this << " SSL_write(" << ssl_.get() << ", "
+                << toWrite << "): " << result << " (" << error << ")";
+              throw std::runtime_error("SSL_write");
+            case SSL_ERROR_SSL:
+              {
+                SPAN_ASSERT(hasBoringSSLError());
+                std::string msg = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_write(" << ssl_.get() << ", "
+                  << toWrite << "): " << result << " (" << error << ", " << msg << ")";
+                throw BoringSSLException(msg);
+              }
+            default:
+              SPAN_NOT_REACHED("SSL_WRITE switch default");
+          }
+        }
+      }
+
+      void TLSStream::flush(bool flushParent) {
+        static const int32 WRITE_BUF_LENGTH = 4096;
+        char writeBuff[WRITE_BUF_LENGTH];
+        int32 toWrite = 0;
+        do {
+          toWrite = BIO_read(writeBio, static_cast<void*>(writeBuff), WRITE_BUF_LENGTH);
+          if (toWrite > 0) {
+            writeBuff_.copyIn(static_cast<const void*>(writeBuff), toWrite);
+          }
+        } while (toWrite > 0);
+
+        while (writeBuff_.readAvailable()) {
+          DLOG(INFO) << this << " parent()->write(" << writeBuff_.readAvailable() << ")";
+          size_t written = parent()->write(&writeBuff_, writeBuff_.readAvailable());
+          DLOG(INFO) << this << " parent()->write(" << writeBuff_.readAvailable() << "): " << written;
+          writeBuff_.consume(written);
+        }
+
+        if (flushParent) {
+          parent()->flush(flushParent);
+        }
+      }
+
+      void TLSStream::accept() {
+        while (true) {
+          uint32 error = SSL_ERROR_NONE;
+          const int32 result = sslCallWithLock(std::bind(SSL_accept, ssl_.get()), &error);
+          if (result > 0) {
+            flush(false);
+            return;
+          }
+          DLOG(INFO) << this << " SSL_accept(" << ssl_.get() << "): "
+            << result << " (" << error << ")";
+          switch (error) {
+            case SSL_ERROR_NONE:
+              flush(false);
+              return;
+            case SSL_ERROR_ZERO_RETURN:
+              // Received close_notify message.
+              return;
+            case SSL_ERROR_WANT_READ:
+              flush();
+              wantRead();
+              continue;
+            case SSL_ERROR_WANT_WRITE:
+            case SSL_ERROR_WANT_CONNECT:
+            case SSL_ERROR_WANT_ACCEPT:
+            case SSL_ERROR_WANT_X509_LOOKUP:
+              SPAN_NOT_REACHED("TlsStream::accept multi case");
+            case SSL_ERROR_SYSCALL:
+              if (hasBoringSSLError()) {
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_accept(" << ssl_.get() << "): "
+                  << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+              LOG(ERROR) << this << " SSL_accept(" << ssl_.get() << "): "
+                << result << " (" << error << ")";
+              if (result == 0) {
+                throw std::runtime_error("Unexpected EoF");
+              }
+              throw std::runtime_error("SSL_accept");
+            case SSL_ERROR_SSL:
+              {
+                SPAN_ASSERT(hasBoringSSLError());
+                std::string message = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_accept(" << ssl_.get() << "): "
+                  << result << " (" << error << ", " << message << ")";
+                throw BoringSSLException(message);
+              }
+            default:
+              SPAN_NOT_REACHED("TlsStream::accept() default switch case");
+          }
+        }
+      }
+
+      void TLSStream::connect() {
+        while (true) {
+          uint32 error = SSL_ERROR_NONE;
+          const int32 result = sslCallWithLock(std::bind(SSL_connect, ssl_.get()), &error);
+          DLOG(INFO) << this << " SSL_connect(" << ssl_.get() << "): " << result
+            << " (" << error << ")";
+          if (result > 0) {
+            flush(false);
+            return;
+          }
+
+          switch (error) {
+            case SSL_ERROR_NONE:
+              flush(false);
+              return;
+            case SSL_ERROR_ZERO_RETURN:
+              // Received close_notify message.
+              return;
+            case SSL_ERROR_WANT_READ:
+              flush();
+              wantRead();
+              continue;
+            case SSL_ERROR_WANT_WRITE:
+            case SSL_ERROR_WANT_ACCEPT:
+            case SSL_ERROR_WANT_CONNECT:
+            case SSL_ERROR_WANT_X509_LOOKUP:
+              SPAN_NOT_REACHED("TlsStream::connect multi-case switch");
+            case SSL_ERROR_SYSCALL:
+              if (hasBoringSSLError()) {
+                std::string msg = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_connect(" << ssl_.get() << "): "
+                  << result << " (" << error << ", " << msg << ")";
+                throw BoringSSLException(msg);
+              }
+              LOG(ERROR) << this << " SSL_connect(" << ssl_.get() << "): "
+                << result << " (" << error << ")";
+              if (result == 0) {
+                throw std::runtime_error("Unexpected EoF exception");
+              }
+              throw std::runtime_error("SSL_connect");
+            case SSL_ERROR_SSL:
+              {
+                SPAN_ASSERT(hasBoringSSLError());
+                std::string msg = getBoringSSLErrorMessage();
+                LOG(ERROR) << this << " SSL_connect(" << ssl_.get() << "): "
+                  << result << " (" << error << ", " << msg << ")";
+                throw BoringSSLException(msg);
+              }
+            default:
+              SPAN_NOT_REACHED("TLSStream::connect default switch statement.");
+          }
+        }
+      }
+
+      void TLSStream::serverNameIndication(std::string hostname) {
+        absl::MutexLock _lock(&mutex_);
+        // Ensure we have null terminator.
+        if (!SSL_set_tlsext_host_name(ssl_.get(), hostname.c_str())) {
+          if (!hasBoringSSLError()) {
+            return;
+          }
+          std::string msg = getBoringSSLErrorMessage();
+          LOG(ERROR) << this << " SSL_set_tlsext_host_name(" << ssl_.get()
+            << ", " << hostname << "): " << msg;
+          throw BoringSSLException(msg);
+        }
+      }
+
+      void TLSStream::verifyPeerCertificate() {
+        const int32 verifyResult = sslCallWithLock(std::bind(SSL_get_verify_result, ssl_.get()), NULL);
+        if (verifyResult) {
+          LOG(WARNING) << this << " SSL_get_verify_result(" << ssl_.get() << "): " << verifyResult;
+        } else {
+          DLOG(INFO) << this << " SSL_get_verify_result(" << ssl_.get() << "): " << verifyResult;
+        }
+        if (verifyResult != X509_V_OK) {
+          throw CertificateVerificationException(verifyResult);
+        }
+      }
+
+      void TLSStream::verifyPeerCertificate(const std::string hostname) {
+        if (hostname.empty()) {
+          throw CertificateVerificationException(
+            X509_V_ERR_APPLICATION_VERIFICATION,
+            "No hostname given");
+        }
+
+        absl::MutexLock _lock(&mutex_);
+        std::shared_ptr<X509> crt;
+        crt.reset(SSL_get_peer_certificate(ssl_.get()), &X509_free);
+        if (!crt) {
+          throw CertificateVerificationException(
+            X509_V_ERR_APPLICATION_VERIFICATION,
+            "No certificate presented");
+        }
+
+        // Ensure null terminated.
+        int32 err = X509_check_host(crt.get(), hostname.c_str(), hostname.length(), 0, NULL);
+        if (err < 0) {
+          throw CertificateVerificationException(err);
+        }
+      }
+
+      void TLSStream::wantRead() {
+        if (readBuff_.readAvailable() == 0) {
+          DLOG(INFO) << this <<  " parent()->read(32768)";
+          const size_t result = parent()->read(&readBuff_, 32768);
+          DLOG(INFO) << this << " parent()->read(32768): " << result;
+          if (result == 0) {
+            BIO_set_mem_eof_return(readBio, 0);
+            return;
+          }
+        }
+
+        SPAN_ASSERT(readBuff_.readAvailable());
+        const iovec iov = readBuff_.readBuffer(~0, false);
+        SPAN_ASSERT(iov.iov_len > 0);
+        const int32 written = BIO_write(readBio, static_cast<char *>(iov.iov_base), iov.iov_len);
+        SPAN_ASSERT(written > 0);
+        readBuff_.consume(written);
+        DLOG(INFO) << this << " wantRead(): " << written;
+      }
+
+      int TLSStream::sslCallWithLock(std::function<int()> dg, uint32 *error) {
+        absl::MutexLock _lock(&mutex_);
+
+        // If error is NULL, it means that sslCallWithLock is not supposed to call
+        // SSL_get_error after dg got called. If SSL_get_error is not supposed to be
+        // called, there is no need to clear current threads error queue.
+        if (error == NULL) {
+          LOG(ERROR) << "sslCallWithLock called without check SSL_get_error!";
+          return dg();
+        }
+
+        clearTLSError();
+        const int result = dg();
+        if (result <= 0) {
+          *error = SSL_get_error(ssl_.get(), result);
+        }
+        return result;
+      }
+    }  // namespace streams
+  }  // namespace io
+}  // namespace span

--- a/span/src/span/io/streams/Tls.hh
+++ b/span/src/span/io/streams/Tls.hh
@@ -1,0 +1,79 @@
+#ifndef SPAN_SRC_SPAN_IO_STREAMS_TLS_HH_
+#define SPAN_SRC_SPAN_IO_STREAMS_TLS_HH_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "span/Common.hh"
+#include "span/io/streams/Buffer.hh"
+#include "span/io/streams/Filter.hh"
+
+#include "absl/synchronization/mutex.h"
+#include "openssl/ssl.h"
+
+namespace span {
+  namespace io {
+    namespace streams {
+      class BoringSSLException : public std::runtime_error {
+      public:
+        BoringSSLException();
+        explicit BoringSSLException(const std::string message) : std::runtime_error(message) {}
+      };
+
+      class CertificateVerificationException : public BoringSSLException {
+      public:
+        explicit CertificateVerificationException(int32 verifyResult) :
+          BoringSSLException(constructMessage(verifyResult)), verifyResult_(verifyResult) {}
+        CertificateVerificationException(int32 verifyResult, const std::string msg) : BoringSSLException(msg),
+          verifyResult_(verifyResult) {}
+
+        int32 verifyResult() const { return verifyResult_; }
+
+      private:
+        static std::string constructMessage(int32 verifyResult);
+        int32 verifyResult_;
+      };
+
+      class TLSStream : public MutatingFilterStream {
+      public:
+        typedef std::shared_ptr<TLSStream> ptr;
+
+        static std::shared_ptr<SSL_CTX> generateSelfSignedCertificate(
+          std::string commonName = std::string("localhost"));
+
+        explicit TLSStream(Stream::ptr parent, bool client = true, bool own = true, SSL_CTX *ctx = NULL);
+
+        bool supportsHalfClose() { return false; }
+
+        void close(CloseType type = BOTH);
+        using MutatingFilterStream::read;
+        size_t read(void *buff, size_t len);
+        size_t write(const Buffer *buff, size_t len);
+        size_t write(const void *buff, size_t len);
+        void flush(bool flushParent = true);
+
+        void accept();
+        void connect();
+
+        void serverNameIndication(const std::string hostname);
+
+        void verifyPeerCertificate();
+        void verifyPeerCertificate(const std::string hostname);
+        void clearTLSError();
+
+      private:
+        void wantRead();
+        int sslCallWithLock(std::function<int()> dg, uint32 *error);
+
+        absl::Mutex mutex_;
+        std::shared_ptr<SSL_CTX> ctx_;
+        std::shared_ptr<SSL> ssl_;
+        Buffer readBuff_, writeBuff_;
+        BIO *readBio, *writeBio;
+      };
+    }  // namespace streams
+  }  // namespace io
+}  // namespace span
+
+#endif  // SPAN_SRC_SPAN_IO_STREAMS_TLS_HH_

--- a/span/tests/pipe_stream_tests.cpp
+++ b/span/tests/pipe_stream_tests.cpp
@@ -1,0 +1,449 @@
+#include "gtest/gtest.h"
+
+#include <utility>
+
+#include "span/fibers/Fiber.hh"
+#include "span/fibers/Scheduler.hh"
+#include "span/fibers/WorkerPool.hh"
+#include "span/io/streams/Buffer.hh"
+#include "span/io/streams/Stream.hh"
+#include "span/io/streams/Pipe.hh"
+
+namespace {
+  TEST(PipeStream, basic) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    ASSERT_TRUE(pipe.first->supportsRead());
+    ASSERT_TRUE(pipe.first->supportsWrite());
+    ASSERT_FALSE(pipe.first->supportsSeek());
+    ASSERT_FALSE(pipe.first->supportsSize());
+    ASSERT_FALSE(pipe.first->supportsTruncate());
+    ASSERT_FALSE(pipe.first->supportsFind());
+    ASSERT_FALSE(pipe.first->supportsUnread());
+
+    ASSERT_TRUE(pipe.second->supportsRead());
+    ASSERT_TRUE(pipe.second->supportsWrite());
+    ASSERT_FALSE(pipe.second->supportsSeek());
+    ASSERT_FALSE(pipe.second->supportsSize());
+    ASSERT_FALSE(pipe.second->supportsTruncate());
+    ASSERT_FALSE(pipe.second->supportsFind());
+    ASSERT_FALSE(pipe.second->supportsUnread());
+
+    span::io::streams::Buffer read;
+    ASSERT_EQ(pipe.first->write("a"), 1u);
+    ASSERT_EQ(pipe.second->read(&read, 10), 1u);
+    ASSERT_TRUE(read == "a");
+    pipe.first->close();
+    ASSERT_EQ(pipe.second->read(&read, 10), 0u);
+  }
+
+  static void basicInFibers(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(*sequence, 1);
+    ASSERT_EQ(stream->write("a"), 1u);
+    stream->close();
+    stream->flush();
+    ++*sequence;
+    ASSERT_EQ(*sequence, 3);
+  }
+
+  TEST(PipeStream, basicInFibers) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+    // pool must destruct before pipe, because wheen pool destructs
+    // it waits for the other fiber to complete, which has a weak ref
+    // to pipe.second; if pipe.second is gone, it will throw an
+    // exception that we don't want.
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(
+      new span::fibers::Fiber(std::bind(&basicInFibers, pipe.first, &sequence))
+    ));
+
+    span::io::streams::Buffer read;
+    ASSERT_EQ(pipe.second->read(&read, 10), 1u);
+    ASSERT_TRUE(read == "a");
+    ++sequence;
+    ASSERT_EQ(sequence, 2);
+    ASSERT_EQ(pipe.second->read(&read, 10), 0u);
+  }
+
+  TEST(PipeStream, readerClosedOne) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    pipe.second->close();
+    ASSERT_THROW(pipe.first->write("a"), std::runtime_error);
+    pipe.first->flush();
+  }
+
+  TEST(PipeStream, readerClosedTwo) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    ASSERT_EQ(pipe.first->write("a"), 1u);
+    pipe.second->close();
+    ASSERT_THROW(pipe.first->flush(), std::runtime_error);
+  }
+
+  TEST(PipeStream, readerGone) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    pipe.second.reset();
+    ASSERT_THROW(pipe.first->write("a"), std::runtime_error);
+  }
+
+  TEST(PipeStream, readerGoneFlush) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    ASSERT_EQ(pipe.first->write("a"), 1u);
+    pipe.second.reset();
+    ASSERT_THROW(pipe.first->flush(), std::runtime_error);
+  }
+
+  TEST(PipeStream, readerGoneReadEverything) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    pipe.second.reset();
+    pipe.first->flush();
+  }
+
+  TEST(PipeStream, writerGone) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    pipe.first.reset();
+    span::io::streams::Buffer buff;
+    ASSERT_THROW(pipe.second->read(&buff, 10), std::runtime_error);
+  }
+
+  static void blockingRead(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(++*sequence, 2);
+    ASSERT_EQ(stream->write("hello"), 5u);
+    ASSERT_EQ(++*sequence, 3);
+  }
+
+  TEST(PipeStream, blockingRead) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(std::bind(
+      &blockingRead, pipe.second, &sequence
+    ))));
+
+    span::io::streams::Buffer buff;
+    ASSERT_EQ(pipe.first->read(&buff, 10), 5u);
+    ASSERT_EQ(++sequence, 4);
+    ASSERT_TRUE(buff == "hello");
+  }
+
+  static void blockingWrite(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(++*sequence, 3);
+    span::io::streams::Buffer output;
+    ASSERT_EQ(stream->read(&output, 10), 5u);
+    ASSERT_TRUE(output == "hello");
+  }
+
+  TEST(PipeStream, blockingWrite) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream(5);
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(
+      std::bind(&blockingWrite, pipe.second, &sequence)
+    )));
+
+    ASSERT_EQ(pipe.first->write("hello"), 5u);
+    ASSERT_EQ(++sequence, 2);
+    ASSERT_EQ(pipe.first->write("world"), 5u);
+    ASSERT_EQ(++sequence, 4);
+
+    span::io::streams::Buffer output;
+    ASSERT_EQ(pipe.second->read(&output, 10), 5u);
+    ASSERT_EQ(++sequence, 5);
+    ASSERT_TRUE(output == "world");
+  }
+
+  TEST(PipeStream, oversizedWrite) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream(5);
+
+    ASSERT_EQ(pipe.first->write("helloworld"), 5u);
+    span::io::streams::Buffer output;
+    ASSERT_EQ(pipe.second->read(&output, 10), 5u);
+    ASSERT_TRUE(output == "hello");
+  }
+
+  static void closeOnBlockingReader(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(++*sequence, 2);
+    stream->close();
+    ASSERT_EQ(++*sequence, 3);
+  }
+
+  TEST(PipeStream, closeOnBlockingReader) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(std::bind(
+      &closeOnBlockingReader, pipe.first, &sequence
+    ))));
+
+    span::io::streams::Buffer buff;
+    ASSERT_EQ(pipe.second->read(&buff, 10), 0u);
+    ASSERT_EQ(++sequence, 4);
+  }
+
+  static void closeOnBlockingWriter(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(++*sequence, 3);
+    stream->close();
+    ASSERT_EQ(++*sequence, 4);
+  }
+
+  TEST(PipeStream, closeOnBlockingWriter) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream(5);
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(std::bind(
+      &closeOnBlockingWriter, pipe.first, &sequence
+    ))));
+
+    ASSERT_EQ(pipe.second->write("hello"), 5u);
+    ASSERT_EQ(++sequence, 2);
+    ASSERT_THROW(pipe.second->write("world"), std::runtime_error);
+    ASSERT_EQ(++sequence, 5);
+  }
+
+  static void destructOnBlockingReader(std::weak_ptr<span::io::streams::Stream> weakStream, int *sequence) {
+    span::io::streams::Stream::ptr stream(weakStream);
+    span::fibers::Fiber::yield();
+    ASSERT_EQ(++*sequence, 2);
+    ASSERT_TRUE(stream.unique());
+    stream.reset();
+    ASSERT_EQ(++*sequence, 3);
+  }
+
+  TEST(PipeStream, destructOnBlockingReader) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    span::fibers::Fiber::ptr fiber = span::fibers::Fiber::ptr(new span::fibers::Fiber(std::bind(
+      &destructOnBlockingReader, std::weak_ptr<span::io::streams::Stream>(pipe.first), &sequence
+    )));
+    fiber->call();
+    pipe.first.reset();
+    pool.schedule(fiber);
+
+    span::io::streams::Buffer output;
+    ASSERT_THROW(pipe.second->read(&output, 10), std::runtime_error);
+    ASSERT_EQ(++sequence, 4);
+  }
+
+  static void destructOnBlockingWriter(std::weak_ptr<span::io::streams::Stream> weakPtr, int *sequence) {
+    span::io::streams::Stream::ptr stream(weakPtr);
+    span::fibers::Fiber::yield();
+    ASSERT_EQ(++*sequence, 3);
+    ASSERT_TRUE(stream.unique());
+    stream.reset();
+    ASSERT_EQ(++*sequence, 4);
+  }
+
+  TEST(PipeStream, destructOnBlockingWriter) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream(5);
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    span::fibers::Fiber::ptr fiber = span::fibers::Fiber::ptr(new span::fibers::Fiber(
+      std::bind(&destructOnBlockingWriter, std::weak_ptr<span::io::streams::Stream>(pipe.first), &sequence)
+    ));
+    fiber->call();
+    pipe.first.reset();
+    pool.schedule(fiber);
+
+    ASSERT_EQ(pipe.second->write("hello"), 5u);
+    ASSERT_EQ(++sequence, 2);
+    ASSERT_THROW(pipe.second->write("world"), std::runtime_error);
+    ASSERT_EQ(++sequence, 5);
+  }
+
+  static void cancelOnBlockingReader(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(++*sequence, 2);
+    stream->cancelRead();
+    ASSERT_EQ(++*sequence, 3);
+  }
+
+  TEST(PipeStream, cancelOnBlockingReader) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(std::bind(
+      &cancelOnBlockingReader, pipe.first, &sequence
+    ))));
+
+    span::io::streams::Buffer output;
+    ASSERT_THROW(pipe.first->read(&output, 10), std::runtime_error);
+    ASSERT_EQ(++sequence, 4);
+    ASSERT_THROW(pipe.first->read(&output, 10), std::runtime_error);
+  }
+
+  static void cancelOnBlockingWriter(span::io::streams::Stream::ptr stream, int *sequence) {
+    ASSERT_EQ(++*sequence, 2);
+    char buff[4096];
+    memset(buff, 0, sizeof(buff));
+    ASSERT_THROW(while (true) { stream->write(&buff, 4096); }, std::runtime_error);
+    ASSERT_EQ(++*sequence, 4);
+    ASSERT_THROW(stream->write(&buff, 4096), std::runtime_error);
+  }
+
+  TEST(PipeStream, cancelOnBlockingWriter) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream(5);
+    span::fibers::WorkerPool pool;
+    int sequence = 1;
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(
+      std::bind(&cancelOnBlockingWriter, pipe.first, &sequence)
+    )));
+    span::fibers::Scheduler::yield();
+    ASSERT_EQ(++sequence, 3);
+    pipe.first->cancelWrite();
+    pool.dispatch();
+    ASSERT_EQ(++sequence, 5);
+  }
+
+  void threadStress(span::io::streams::Stream::ptr stream) {
+    size_t totalRead = 0;
+    size_t totalWritten = 0;
+    size_t buff[64];
+    span::io::streams::Buffer buffer;
+    for (int idx = 0; idx < 10000; ++idx) {
+      if (idx % 2) {
+        size_t toRead = 64;
+        size_t read = stream->read(&buffer, toRead * sizeof(size_t));
+        ASSERT_EQ(read % sizeof(size_t), 0);
+        buffer.copyOut(&buff, read);
+        for (size_t jdx = 0; read > 0; read -= sizeof(size_t), ++jdx) {
+          ASSERT_EQ(buff[jdx], ++totalRead);
+        }
+        buffer.clear();
+      } else {
+        size_t toWrite = 64;
+        for (size_t jdx = 0; jdx < toWrite; ++jdx) {
+          buff[jdx] = ++totalWritten;
+        }
+        buffer.copyIn(&buff, toWrite * sizeof(size_t));
+        size_t written = stream->write(&buffer, toWrite * sizeof(size_t));
+        totalWritten -= (toWrite - written / sizeof(size_t));
+        buffer.clear();
+      }
+    }
+
+    stream->close(span::io::streams::Stream::WRITE);
+
+    while (true) {
+      size_t toRead = 64;
+      size_t read = stream->read(&buffer, toRead);
+      if (read == 0) {
+        break;
+      }
+      ASSERT_EQ(read % sizeof(size_t), 0);
+      buffer.copyOut(&buff, read);
+      for (size_t idx = 0; read > 0; read -= sizeof(size_t), ++idx) {
+        ASSERT_EQ(buff[idx], ++totalRead);
+      }
+      buffer.clear();
+    }
+
+    stream->flush();
+  }
+
+  TEST(PipeStream, threadStress) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+    span::fibers::WorkerPool pool(2);
+
+    pool.schedule(span::fibers::Fiber::ptr(new span::fibers::Fiber(
+      std::bind(&threadStress, pipe.first)
+    )));
+    threadStress(pipe.second);
+  }
+
+  static void closed(bool *remoteClosed) {
+    *remoteClosed = true;
+  }
+
+  TEST(PipeStream, eventOnRemoteClose) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    bool remoteClosed = false;
+    pipe.first->onRemoteClose(std::bind(&closed, &remoteClosed));
+    pipe.second->close();
+    ASSERT_TRUE(remoteClosed);
+  }
+
+  TEST(PipeStream, eventOnRemoteReset) {
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    bool remoteClosed = false;
+    pipe.first->onRemoteClose(std::bind(&closed, &remoteClosed));
+    pipe.second.reset();
+    ASSERT_TRUE(remoteClosed);
+  }
+}  // namespace

--- a/span/tests/tls_stream_tests.cpp
+++ b/span/tests/tls_stream_tests.cpp
@@ -1,0 +1,43 @@
+#include "gtest/gtest.h"
+
+#include <utility>
+
+#include "span/fibers/WorkerPool.hh"
+#include "span/io/streams/Pipe.hh"
+#include "span/io/streams/Stream.hh"
+#include "span/io/streams/Tls.hh"
+
+namespace {
+  static void test_accept(span::io::streams::TLSStream::ptr server) {
+    server->accept();
+    server->flush();
+  }
+
+  TEST(TlsStream, basic) {
+    span::fibers::WorkerPool pool;
+    std::pair<
+      span::io::streams::Stream::ptr,
+      span::io::streams::Stream::ptr
+    > pipe = span::io::streams::pipeStream();
+
+    span::io::streams::TLSStream::ptr sslServer(new span::io::streams::TLSStream(pipe.first, false));
+    span::io::streams::TLSStream::ptr sslClient(new span::io::streams::TLSStream(pipe.second, true));
+
+    pool.schedule(std::bind(&test_accept, sslServer));
+    sslClient->connect();
+    pool.dispatch();
+
+    span::io::streams::Stream::ptr server = sslServer, client = sslClient;
+
+    char buff[6];
+    buff[5] = '\0';
+    client->write("hello");
+    client->flush(false);
+    ASSERT_EQ(server->read(&buff, 5), 5u);
+    ASSERT_STREQ(buff, "hello");
+    server->write("world");
+    server->flush(false);
+    ASSERT_EQ(client->read(&buff, 5), 5u);
+    ASSERT_STREQ(buff, "world");
+  }
+}  /// namespace

--- a/tools/cpp/workspace.bzl
+++ b/tools/cpp/workspace.bzl
@@ -18,3 +18,9 @@ def cxx_workspace():
     urls = ["https://github.com/google/cctz/archive/master.zip"],
     strip_prefix = "cctz-master",
   )
+
+  native.git_repository(
+    name = "boringssl",
+    commit = "1c91287e05463520c75877af46b665880d11ab63",
+    remote = "https://boringssl.googlesource.com/boringssl",
+  )


### PR DESCRIPTION
## Motivation (required) ##

This PR adds in support for TLS/SSL over a streaming fashion. Allowing you to simply wrap an existing stream (whatever that might be) in a: `TlsStream(myExistingStream(), isServer)`, and have it automatically act as a TLS Server/Client should.

## Test Plan (required) ##

I've added in some tests for the Pipe Stream, and one test for TLS Stream (although TLS Stream will have more tests coming later). So, for now, we just need to test that all the tests pass on CI.

## Next Steps ##

- Once this has been merged in we can continue porting over TLS Stream tests for upstream mordor.